### PR TITLE
Enable to generate gen_config binaries for apple silicon

### DIFF
--- a/AntiHackOSS/tools/config/Makefile
+++ b/AntiHackOSS/tools/config/Makefile
@@ -2,10 +2,11 @@
 
 NAME := gen_config
 
-ALL: $(NAME)_mac $(NAME)_linux $(NAME)_windows.exe
+ALL: $(NAME)_mac_intel $(NAME)_mac_applesilicon $(NAME)_linux $(NAME)_windows.exe
 
 clean:
-	rm -f $(NAME)_mac
+	rm -f $(NAME)_mac_intel
+	rm -f $(NAME)_mac_applesilicon
 	rm -f $(NAME)_windows.exe
 	rm -f $(NAME)_linux
 	rm -f $(NAME)_android
@@ -13,12 +14,14 @@ clean:
 
 SRCS := GenConfig.go
 
-$(NAME)_mac: $(SRCS)
-	GOOS=darwin GOARCH=amd64 go build -o $@ 
-$(NAME)_windows.exe: $(SRCS)
-	GOOS=windows GOARCH=386 go build -o $@
-$(NAME)_linux: $(SRCS)
-	GOOS=linux GOARCH=amd64 go build -o $@
-$(NAME)_android: $(SRCS)
-	GOOS=linux GOARCH=arm go build -o $@
+$(NAME)_mac_intel:
+	GOOS=darwin GOARCH=amd64 go build -o $@ $(SRCS)
+$(NAME)_mac_applesilicon:
+	GOOS=darwin GOARCH=arm64 go build -o $@ $(SRCS)
+$(NAME)_windows.exe:
+	GOOS=windows GOARCH=386 go build -o $@ $(SRCS)
+$(NAME)_linux:
+	GOOS=linux GOARCH=amd64 go build -o $@ $(SRCS)
+$(NAME)_android:
+	GOOS=linux GOARCH=arm go build -o $@ $(SRCS)
 

--- a/AntiHackOSS/tools/release.sh
+++ b/AntiHackOSS/tools/release.sh
@@ -10,6 +10,7 @@ pushd $(dirname $0) > /dev/null
 cd ../
 
 rm -rf ./Release/
+rm -rf ./Release-$1/
 mkdir -p ./Release/compiler/bin/
 mkdir -p ./Release/compiler/lib/
 
@@ -39,9 +40,16 @@ popd > /dev/null
 pushd $(dirname $0) > /dev/null
 cd ../
 
-# cp -v tools/config/config.pre.json ./Release/
-cp -v tools/config/gen_config_* ./Release/
-cp -v tools/config/gen_config.sh ./Release/
+mkdir -p ./Release/gen_config/bin/macOS/Intel
+mkdir -p ./Release/gen_config/bin/macOS/AppleSilicon
+mkdir -p ./Release/gen_config/bin/Windows
+mkdir -p ./Release/gen_config/bin/Linux
+
+cp -v tools/config/gen_config_mac_intel ./Release/gen_config/bin/macOS/Intel/gen_config
+cp -v tools/config/gen_config_mac_applesilicon ./Release/gen_config/bin/macOS/AppleSilicon/gen_config
+cp -v tools/config/gen_config_linux ./Release//gen_config/bin/Linux/gen_config.exe
+cp -v tools/config/gen_config_windows.exe ./Release/gen_config/bin/Windows/gen_config
+cp -v tools/config/gen_config.sh ./Release/gen_config
 
 mkdir -p ./Release/script/
 cp -v script/*setup.sh ./Release/script/


### PR DESCRIPTION
gen_configのApple Silicon Mac向けバイナリを生成できるようにしました。それに伴いReleaseフォルダの構造を各アーキテクチャ向けのバイナリ毎にフォルダを分けるように変更しました。

```
$ tree Release-hoge/
.
├── LICENSE-DeClang
├── LICENSE-ollvm
├── LICENSE.txt
├── compiler
│   ├── bin
│   │   ├── clang
│   │   └── clang++
│   ├── include
│   │   ├── c++
│   │   │   └── v1
│   │   │       ├── CMakeLists.txt
│   │   │       ├── __availability
....
├── gen_config
│   ├── bin
│   │   ├── Linux
│   │   │   └── gen_config.exe
│   │   ├── Windows
│   │   │   └── gen_config
│   │   └── macOS
│   │       ├── AppleSilicon
│   │       │   └── gen_config
│   │       └── Intel
│   │           └── gen_config
│   └── gen_config.sh
└── script
    ├── ndk_setup.sh
    ├── ndk_unset.sh
    ├── xcode_setup.sh
    └── xcode_unset.sh
```