### PR TITLE
Delete unused copy.sh

### DIFF
--- a/AntiHackOSS/tools/config/copy.sh
+++ b/AntiHackOSS/tools/config/copy.sh
@@ -1,5 +1,0 @@
-pushd $(dirname $0) > /dev/null
-
-cp -v gen_config_mac ~/.DeClang/
-
-popd > /dev/null


### PR DESCRIPTION
開発初期のテスト用と思われる`AntiHackOSS/tools/config/copy.sh`を消しました。macOS以外では意味をなさないファイルなので、消したほうがよさそうです