### PR TITLE
Reduce build time by disabling builds of unnecessary files

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -43,6 +43,9 @@ else
       cmake \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_ENABLE_DUMP=ON \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
         -DLLVM_ENABLE_PROJECTS=clang \
         -DLLVM_CCACHE_BUILD=${use_ccache}\
         -DLLVM_USE_CRT_RELEASE=MT \
@@ -54,6 +57,9 @@ else
     else
       cmake \
         -DLLVM_ENABLE_DUMP=ON \
+        -DLLVM_INCLUDE_BENCHMARKS=OFF \
+        -DLLVM_INCLUDE_EXAMPLES=OFF \
+        -DLLVM_INCLUDE_TESTS=OFF \
         -DCMAKE_BUILD_TYPE=Release \
         -DLLVM_ENABLE_PROJECTS=clang \
         -DLLVM_CCACHE_BUILD=${use_ccache}\


### PR DESCRIPTION
LLVMに対するテストコード、サンプルファイルなど、DeClangの動作に不要なファイルのビルドを抑制し、手元の環境（Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz, RAM 32GB, MacBook Pro）でビルド時間を7分短縮しました。
`clang`のハッシュ値がビルドプロセス変更前後で変化しないことを確認しています。


before:

```
$ time bash ./build.sh
real	41m54.233s
user	417m16.314s
sys	21m5.020s
````

after:

```
time bash ./build.sh
real	34m11.011s
user	375m17.852s
sys	18m20.577s
```
