### PR TITLE
Add explanation of config and notes on building with gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ the above script in MYSYS2 shell. Also, Visual Studio 2017 is required for build
   | build_seed | default seed to be used by obfuscation | string |
   | overall_obfuscation | strength of simple obfuscation for overall code | integer 0-100 (default 0) |
   | flatten[name] | function name to be flatten-obfuscated | regex string |
+  | flatten[seed] | seed to be used by flatten-obfuscation | 16-digit hexadecimal string |
+  | flatten[split_level] | level to split Basic Block for flatten-obfuscation | integer (default 1)|
+  | enable_obfuscation | enable/disable flatten-obfuscation | integer 0-1 (default 1) |
 
 - Generate config.json from config.pre.json:
   ```
@@ -116,4 +119,6 @@ System.Environment.SetEnvironmentVariable("DECLANG_HOME", "/path/to/DeClang/");
 - If you do not set DECLANG_HOME, DeClang will use the default directory `~/.DeClang/`
 - Note that usually DeClang for NDK and DeClang for Xcode might not be compatitable with each other so when you install & setup DeClang 
 for different architecture please make sure you are using the correct DeClang version.
-
+- When building the Android library using Gradle, run `ndk_setup.sh` according to the `ndkVersion` listed in build.gradle.
+Also, please enable the optimization by mentioning `set(CMAKE_CXX_FLAGS_RELEASE "-O2") ` in the CMakefile.txt file.
+If DeClang does not enable optimization, the process will not be passed to LLVM Pass, which performs obfuscation.

--- a/README_JP.md
+++ b/README_JP.md
@@ -81,6 +81,9 @@ $ bash release.sh v1.0.0
   | build_seed | 難読化で利用されるシード | string |
   | overall_obfuscation | コード全体に適用される簡易難読化の強さ | integer 0-100 (default 0) |
   | flatten[name] | flatten難読化を適用する関数名 | regex string |
+  | flatten[seed] | flatten難読化内部で使用するシード値 | 16-digit hexadecimal string |
+  | flatten[split_level] | flatten難読化の際にBasic Blockを分割するレベル | integer (default 1)|
+  | enable_obfuscation | flatten難読化を有効にするか否か | integer 0-1 (default 1) |
 
 - config.pre.jsonからconfig.jsonを生成します。
   ```
@@ -93,3 +96,7 @@ $ bash release.sh v1.0.0
 ## 注意点
 
 Unity上でビルドするときは、$DECLANG_HOMEは効かないので、デフォルトの~/.DeClang/が使われてしまいます。なのでコマンドラインからDECLANG_HOMEを設定した状態でビルドしてください。
+
+Gradleを用いてAndroidライブラリをビルドするときは、build.gradle内に記載されている`ndkVersion`に応じて、`ndk_setup.sh`を実行してください。
+また、CMakefile.txt内で`set(CMAKE_CXX_FLAGS_RELEASE "-O2") ` を記載し、最適化を有効にしてください。
+DeClangは最適化を有効にしないと、難読化を行うLLVM Passに処理が渡らず、難読化が行われません。


### PR DESCRIPTION
GradleからDeClangを使う際の注意事項について記載。ついでにconfig内の`flatten[seed]`、`flatten[split_level]`、`enable_obfuscation`についても記載しました。
