### PR TITLE
Changed to find universal binaries on macOS for ndk_setup.sh/ndk_unset.sh

### DIFF
--- a/script/ndk_setup.sh
+++ b/script/ndk_setup.sh
@@ -22,7 +22,7 @@ if [ "_$OS" = "_Windows_NT" ]; then # MSYS2
 elif uname -r | grep -i microsoft > /dev/null; then # WSL2
   ndk_clang_path=`find "$ndk_path" -type f -name "clang++.exe"`
 else
-  ndk_clang_path=`find "$ndk_path" -type f -name "clang++"`
+  ndk_clang_path=`find "$ndk_path" -name "clang++"`
 fi
 
 darwin_path=`dirname "$ndk_clang_path"`

--- a/script/ndk_unset.sh
+++ b/script/ndk_unset.sh
@@ -15,7 +15,7 @@ if [ "_$OS" = "_Windows_NT" ]; then # MSYS2
 elif uname -r | grep -i microsoft > /dev/null; then # WSL2
   ndk_clang_path=`find "$ndk_path" -type f -name "clang++.exe"`
 else
-  ndk_clang_path=`find "$ndk_path" -type f -name "clang++"`
+  ndk_clang_path=`find "$ndk_path" -name "clang++"`
 fi
 
 darwin_path=`dirname "$ndk_clang_path"`


### PR DESCRIPTION
最近のmacOS向けのNDK内のclang/clang++バイナリはuniversal binaryになっているようです。
universal binaryはfind -type fだと見つけられないことがわかったので、対応するためのプルリクエストです。

```
$ find "/Users/tkmru/Library/Android/sdk/ndk/23.2.8568313" -type f -name clang++
何もでない

$ find "/Users/tkmru/Library/Android/sdk/ndk/23.2.8568313" -name clang++
/Users/tkmru/Library/Android/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++

$ file /Users/tkmru/Library/Android/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++
/Users/tkmru/Library/Android/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
/Users/tkmru/Library/Android/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ (for architecture x86_64):	Mach-O 64-bit executable x86_64
/Users/tkmru/Library/Android/sdk/ndk/23.2.8568313/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang++ (for architecture arm64):	Mach-O 64-bit executable arm64
```