### PR TITLE
fix __ANDROID_API__ macro

### DIFF
--- a/clang/lib/Basic/Targets/OSTargets.h
+++ b/clang/lib/Basic/Targets/OSTargets.h
@@ -378,7 +378,7 @@ protected:
         Builder.defineMacro("__ANDROID_MIN_SDK_VERSION__", Twine(Maj));
         // This historical but ambiguous name for the minSdkVersion macro. Keep
         // defined for compatibility.
-        Builder.defineMacro("__ANDROID_API__", "__ANDROID_MIN_SDK_VERSION__");
+        Builder.defineMacro("__ANDROID_API__", Twine(Maj));
       }
     } else {
         Builder.defineMacro("__gnu_linux__");


### PR DESCRIPTION
# 概要
swift 5.9移行時に、Android NDK 23対応で入っていたANDROID_APIマクロの修正が抜けていたため、こちらで再度修正を行いました。